### PR TITLE
Fix buildwar

### DIFF
--- a/doj/management/commands/__init__.py
+++ b/doj/management/commands/__init__.py
@@ -6,6 +6,8 @@ from django.conf import settings
 
 
 class DOJConfigurationMixin(object):
+    __base_dir = None
+
     def _setup(self, args, options):
         """
         Makes the given arguments an options available


### PR DESCRIPTION
This modification fix exception

```
$ jython manage.py buildwar
System check identified some issues:

WARNINGS:
todo.TODO.completed: (1_6.W002) BooleanField does not have a default value.
    HINT: Django 1.6 changed the default value of BooleanField from False to None. See https://docs.djangoproject.com/en/1.6/ref/models/fields/#booleanfield for more information.
Assembling WAR
  Copy skeleton... OK
  Copy media... SKIP
  Copy static... SKIP
  Copy apps... OK
  Copy python packages... OK
  Copy java libraries... OK
  Copy additional directories... OK
  Process skeleton templates...Traceback (most recent call last):
  File "manage.py", line 13, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/toidi/sandbox/jython/jython2.7b3/Lib/site-packages/Django-1.7-py2.7.egg/django/core/management/__init__.py", line 385, in execute_from_command_line
    utility.execute()
  File "/Users/toidi/sandbox/jython/jython2.7b3/Lib/site-packages/Django-1.7-py2.7.egg/django/core/management/__init__.py", line 377, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/toidi/sandbox/jython/jython2.7b3/Lib/site-packages/Django-1.7-py2.7.egg/django/core/management/base.py", line 288, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/Users/toidi/sandbox/jython/jython2.7b3/Lib/site-packages/Django-1.7-py2.7.egg/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/Users/toidi/sandbox/jython/jython2.7b3/Lib/site-packages/Django-1.7-py2.7.egg/django/core/management/base.py", line 533, in handle
    return self.handle_noargs(**options)
  File "/Users/toidi/sandbox/jython/jython2.7b3/Lib/site-packages/django_jython-1.7.0b2-py2.7.egg/doj/management/commands/buildwar.py", line 137, in handle_noargs
    self.do_process_templates()
  File "/Users/toidi/sandbox/jython/jython2.7b3/Lib/site-packages/django_jython-1.7.0b2-py2.7.egg/doj/management/commands/buildwar.py", line 306, in do_process_templates
    context = Context({
  File "/Users/toidi/sandbox/jython/jython2.7b3/Lib/site-packages/django_jython-1.7.0b2-py2.7.egg/doj/management/commands/__init__.py", line 48, in _get_project_name
    project_name = os.path.basename(self._get_base_dir())
  File "/Users/toidi/sandbox/jython/jython2.7b3/Lib/site-packages/django_jython-1.7.0b2-py2.7.egg/doj/management/commands/__init__.py", line 28, in _get_base_dir
    if not self.__base_dir:
AttributeError: 'Command' object has no attribute '_DOJConfigurationMixin__base_dir'
```
